### PR TITLE
Configure ruff via pyproject.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,5 +20,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jpetrucciani/ruff-check@main
-        with:
-          flags: '--ignore E501' # ignore long lines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+# ignore long lines
+ignore = ["E501"]


### PR DESCRIPTION
So it uses the same flags whether it is run in the CI or outside.