### PR TITLE
Updates to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Analysis Grand Challenge (AGC) benchmarks with ROOT
 
 The Analysis Grand Challenge (AGC) is about performing the last steps in an analysis pipeline at scale to test workflows envisioned for the HL-LHC.
-This includes
+This includes:
 
-- columnar data extraction from large datasets,
-- processing of that data (event filtering, construction of observables, evaluation of systematic uncertainties) into histograms,
-- statistical model construction and statistical inference,
-- relevant visualizations for these steps,
+- columnar data extraction from large datasets
+- processing of that data (event filtering, construction of observables, evaluation of systematic uncertainties) into histograms
+- statistical model construction and statistical inference
+- visualizations for these steps
 
 all done in a reproducible & preservable way that can scale to HL-LHC requirements.
 
-The reference implementation of the workflows is hosted at https://github.com/iris-hep/analysis-grand-challenge. This repository demonstrates usage of ROOT facilities in the same type of benchmarks. The physics analyses code can be found in the `analyses` folder.
+The official AGC documentation can be found [at this link](https://agc.readthedocs.io/en/latest/index.html).
+
+This repository implements AGC analysis tasks using modern ROOT interfaces.
+
+The physics analyses implementations can be found in the `analyses` folder.

--- a/analyses/cms-open-data-ttbar/README.md
+++ b/analyses/cms-open-data-ttbar/README.md
@@ -1,11 +1,23 @@
-The physics analysis task is a $t\bar{t}$ cross-section measurement with 2015 CMS Open Data. Currently, the benchmark is fixed at the reference implementation tag [v0.1.0](https://github.com/iris-hep/analysis-grand-challenge/tree/v0.1.0). The first RDataFrame implementation of this task is a work by Andrii Falko and can be found at https://github.com/andriiknu/analysis-grand-challenge.
+# $t\bar{t}$ analysis
 
-The benchmark assumes the latest ROOT version 6.28 is used. For installation instructions, refer to https://root.cern/install.
+The physics analysis task is a $t\bar{t}$ cross-section measurement with 2015 CMS Open Data.
 
-To run the analysis:
+A full explanation of the analysis task is available [at this link](https://agc.readthedocs.io/en/latest/taskbackground.html).
+
+The current implementation corresponds to [AGC version 0.1.0](https://github.com/iris-hep/analysis-grand-challenge/tree/v0.1.0).
+
+## Running the analysis
+
+ROOT v6.28 or later is required (see https://root.cern/install for installation instructions).
+
+The full analysis can be run in multi-thread mode with:
 
 ```
-python analysis.py [OPTIONS ...]
+python analysis.py
 ```
 
-To see the full list of options, run `python analysis.py -h`. RDataFrame supports local or distributed mode, which can be toggled via `--scheduling-mode [imt, dask-local, ...]`.
+Use `python analysis.py -h` to see the full list of options, including how to switch between local multi-threading and distributed execution.
+
+## Acknowledgements
+
+The first RDataFrame implementation of this task was a work by Andrii Falko (@andriiknu) sponsored by the IRIS-HEP Fellows Program.


### PR DESCRIPTION
The main change is adding pointers to https://agc.readthedocs.io/en/latest and the full explanation of the ttbar analysis task.