### PR TITLE
Set minimal Python version as 3.9 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ name: root-agc
 channels:
   - conda-forge
 dependencies:
-  - python=3
+  - python>=3.9
   - root
   - distributed


### PR DESCRIPTION
We want to be able to use 3.9's type annotations.