### PR TITLE
Fix btag cuts to always use > rather than >=

### DIFF
--- a/analyses/cms-open-data-ttbar/analysis.py
+++ b/analyses/cms-open-data-ttbar/analysis.py
@@ -250,10 +250,7 @@ def book_histos(
     # Only one b-tagged region required
     # The observable is the total transvesre momentum
     # fmt: off
-
-    # not strict condition is used because the same selection cut is applied in the reference implementation
-    # https://github.com/iris-hep/analysis-grand-challenge/blob/main/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py#L254
-    df4j1b = df.Filter("Sum(Jet_btagCSVV2_ptcut >= 0.5) == 1")\
+    df4j1b = df.Filter("Sum(Jet_btagCSVV2_ptcut > 0.5) == 1")\
                .Define("HT", "Sum(Jet_pt_ptcut)")
     # fmt: on
 


### PR DESCRIPTION
We only used >= in one place in order to be
consistent with the reference implementation.
Since release v1.2 the reference implementation
also switched to always using > as per the spec,
so we move to the correct cuts too.