### PR TITLE
Trigger jitting once at the end instead of many times 

### DIFF
--- a/analyses/cms-open-data-ttbar/utils.py
+++ b/analyses/cms-open-data-ttbar/utils.py
@@ -28,6 +28,8 @@ class AGCResult:
     # in v6.28 we need a RResultPtr to pass to RDF.RunGraphs in order to trigger the event loop.
     # In later versions RunGraphs accepts RResultMaps as well, and we don't need this data attribute.
     nominal_histo: ROOT.RDF.RResultPtr[ROOT.TH1D]
+    # Whether we should call VariationsFor over histo to produce variations
+    should_vary: bool = False
 
 
 def _tqdm_urlretrieve_hook(t: tqdm):


### PR DESCRIPTION
VariationsFor in turn calls RLoopManager::Jit.
By moving calls to VariationsFor outside of the
main compute graph building logic we jit all of
the required code once, together, which reduced
the runtime of the setup time by a factor 3 on my
laptop (~30 seconds to ~10 seconds).

N.B.
only the last commit is relevant for this PR, which is sitting on top of #38 .